### PR TITLE
Move dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,17 +7,17 @@
     "test": "test"
   },
   "dependencies": {
+    "joi": "^6.6.1"
+  },
+  "devDependencies": {
     "expect.js": "^0.3.1",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-eslint": "^17.1.0",
-    "joi": "^6.6.1",
+    "mocha": "^2.2.5",
     "pre-commit": "^1.1.1",
     "rewire": "^2.3.4",
     "time-grunt": "^1.2.1"
-  },
-  "devDependencies": {
-    "mocha": "^2.2.5"
   },
   "scripts": {
     "test": "grunt && node_modules/mocha/bin/mocha --reporter spec --timeout 5s"


### PR DESCRIPTION
Grunt has a DoS issue currently, and it is causing the search API build to fail. 

Moving grunt to devDependencies will fix the issue
